### PR TITLE
fix: #9 解决解释样式重叠

### DIFF
--- a/src/components/Explanations.vue
+++ b/src/components/Explanations.vue
@@ -31,7 +31,7 @@ const parseNestedExplanations = (
       const lexicalIcon = item.lexical
         ? `<span
     class="seeicon- mr-1 inline-block align-text-bottom text-rosybrown-700"
-    style="font-size: 20px"
+    style="font-size: 20px; display: inline-block; width: 1em;"
     >${item.lexical}</span>`
         : '';
       const processedExpl = `${lexicalIcon}${replaceChineseQuotes(toggleGlyph(item.expl, props.currentGlyph))}`;

--- a/src/components/SeeSymbol.vue
+++ b/src/components/SeeSymbol.vue
@@ -1,5 +1,5 @@
 <template>
-  <span class="seeicon- mr-1 align-text-bottom" style="font-size: 20px"
+  <span class="seeicon- mr-1 align-text-bottom" style="font-size: 20px; display: inline-block; width: 1em;"
     ><slot></slot
   ></span>
 </template>


### PR DESCRIPTION
#9 
修复了 Safari 设备上，词汇页 “解释” 元素重叠问题

在 Explanations 和 SeeSymbol（不确定要不要对这个文件修改）中增加了 `display: inline-block; width: 1em;`，详见 change