### PR TITLE
ci: 由 master 分支构建 GitHub Page

### DIFF
--- a/.github/workflows/gh-page.yaml
+++ b/.github/workflows/gh-page.yaml
@@ -2,9 +2,7 @@ name: Deploy Vue3 with Github Pages
 
 on:
   push:
-    branches: ["vue3-dev"]
-  pull_request:
-    branches: ["vue3-dev"]
+    branches: ["master"]
 
 permissions:
   contents: write

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,0 @@
-{
-  "recommendations": ["Vue.volar"]
-}


### PR DESCRIPTION
部署方式变更，不再采用 `master` 推送部署，以 release 作为新功能推送节点。因而可以弃用 `vue-dev` 分支，直接从 `master` 分支生成测试页面