### PR TITLE
重命名搜索模式 + 默认改为按意思查

### DIFF
--- a/src/components/SearchModeSwitch.vue
+++ b/src/components/SearchModeSwitch.vue
@@ -64,12 +64,12 @@ const modeOptions: Array<{
 }> = [
   {
     mode: 'fuzzy',
-    label: '模糊搜索',
-    description: '由关键字模糊查询词汇',
+    label: '按字词查',
+    description: '由关键字匹配查询词汇',
   },
   {
     mode: 'semantic',
-    label: '语义搜索',
+    label: '按意思查',
     description: '由内容的语义查询词汇',
   },
 ];

--- a/src/store/searchModeStore.ts
+++ b/src/store/searchModeStore.ts
@@ -7,11 +7,11 @@ const STORAGE_KEY = 'seedict.searchMode';
 
 const readStoredMode = (): SearchMode => {
   if (typeof window === 'undefined') {
-    return 'fuzzy';
+    return 'semantic';
   }
 
   const value = window.localStorage.getItem(STORAGE_KEY);
-  return value === 'semantic' ? 'semantic' : 'fuzzy';
+  return value === 'fuzzy' ? 'fuzzy' : 'semantic';
 };
 
 export const searchRouteNameByMode: Record<SearchMode, 'search' | 'semantic-search'> = {


### PR DESCRIPTION
## 改动

### 按钮文案 (`SearchModeSwitch.vue`)

| | 旧 | 新 |
|---|---|---|
| `fuzzy` 按钮 | 模糊搜索 | **按字词查** |
| `fuzzy` 说明 | 由关键字模糊查询词汇 | 由关键字匹配查询词汇 |
| `semantic` 按钮 | 语义搜索 | **按意思查** |
| `semantic` 说明 | 由内容的语义查询词汇 | （不变）|

### 默认模式 (`searchModeStore.ts`)

新访客（无 `seedict.searchMode` localStorage）默认进入 **按意思查**（原默认按字词查）。

| 场景 | 旧 | 新 |
|---|---|---|
| Fresh visitor (无 localStorage) | `fuzzy` | **`semantic`** |
| 有 `fuzzy` 偏好的回访 | `fuzzy` | `fuzzy`（沿用）|
| 有 `semantic` 偏好的回访 | `semantic` | `semantic`（沿用）|

路由级同步保持不变：进入 `/search` 仍把 mode 同步成 `fuzzy`，进入 `/semantic-search` 同步成 `semantic`。

## 动机

- 文案：「按字词查 / 按意思查」比「模糊 / 语义」更直观，避免「模糊 = 不精确」的负面联想
- 默认按意思查：语义召回 + cross-encoder 重排（`/api/v2/search/semantic/`）已是更友好的入口，让首次访问的用户直接吃到这套能力

## 测试

新访客在 DevTools → Application → Local Storage 里清掉 `seedict.searchMode` 后刷新，SearchBar 应默认显示「按意思查」并把回车后的路由指向 `/semantic-search`。